### PR TITLE
Use Openstruct instead of Hash for @json field in RingCaptchaVerification

### DIFF
--- a/lib/ringcaptcha.rb
+++ b/lib/ringcaptcha.rb
@@ -9,7 +9,7 @@ module RingCaptcha
   class RingCaptchaVerification
 
     extend Forwardable
-    PUBLIC_METHODS = [:status, :message, :transaction_id, :phone_number,  :geolocation, :phone_type, :carrier_name, :roaming, :risk, :json]
+    PUBLIC_METHODS = [:status, :message, :transaction_id, :phone,  :geolocation, :phone_type, :carrier_name, :roaming, :risk, :json]
 
     PUBLIC_METHODS.each do |m|
       def_delegators :@json, m

--- a/lib/ringcaptcha.rb
+++ b/lib/ringcaptcha.rb
@@ -1,6 +1,7 @@
 require 'open-uri'
 require 'net/http'
 require 'json'
+require 'ostruct'
 
 module RingCaptcha
   class RingCaptchaRequestError < StandardError; end
@@ -15,15 +16,15 @@ module RingCaptcha
     end
 
     def initialize(json)
-      @json = json
+      @json = OpenStruct.new(json)
     end
 
     def valid?
-      @status == "SUCCESS"
+      status == "SUCCESS"
     end
 
     def as_json(options={})
-      @json.slice(*PUBLIC_METHODS.map(&:to_s))
+      @json.to_h.slice(*PUBLIC_METHODS)
     end
   end
 


### PR DESCRIPTION
I made these changes, because the `valid?` method didn't work.
`@status` field is always `nil`, then `@status == "SUCCESS"` is always `false`.
Moreover, when delegating, for example, `:status` to the `@json` hash, errors happen.
Something like

    undefined method `status' for {*hash_contents*}:Hash

Maybe I'm missing something, in this case, please, tell me what I'm getting wrong.
Anyway, with these changes, I can make this gem work in my application.